### PR TITLE
bug: update with module and fix empty struct

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,48 @@
+FROM ubuntu:jammy
+
+LABEL maintainer="Vanessasaurus <@vsoch>"
+
+# Match the default user id for a single system so we aren't root
+ARG USERNAME=vscode
+ARG USER_UID=1000
+ARG USER_GID=1000
+ENV USERNAME=${USERNAME}
+ENV USER_UID=${USER_UID}
+ENV USER_GID=${USER_GID}
+USER root
+
+# Install extra buildrequires for flux-sched:
+RUN apt-get update && \
+    apt-get -qq install -y --no-install-recommends \
+        wget \
+        curl \ 
+        less \
+        git \
+        locales \
+        autoconf \
+        libtool \
+        automake \
+        build-essential \
+        ca-certificates
+
+# Assuming installing to /usr/local
+ENV LD_LIBRARY_PATH=/usr/lib:/usr/local/lib
+ENV PATH=$PATH:/workspaces/hwloc-go/bin
+
+RUN wget --no-check-certificate https://go.dev/dl/go1.21.7.linux-amd64.tar.gz && tar -xvf go1.21.7.linux-amd64.tar.gz && \
+         mv go /usr/local && rm go1.21.7.linux-amd64.tar.gz
+
+# Install hwloc
+RUN git clone https://github.com/open-mpi/hwloc /opt/hwloc && \
+    cd /opt/hwloc && \
+    ./autogen.sh && \
+    ./configure --enable-static --disable-shared LDFLAGS="-static" && \
+    make LDFLAGS=-all-static && \
+    make install && ldconfig /usr/local/lib
+
+ENV PATH=$PATH:/usr/local/go/bin:/home/vscode/go/bin
+
+# Add the group and user that match our ids
+RUN groupadd -g ${USER_GID} ${USERNAME} && \
+    adduser --disabled-password --uid ${USER_UID} --gid ${USER_GID} --gecos "" ${USERNAME} && \
+    echo "${USERNAME} ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,17 @@
+{
+  "name": "hwloc-go Environment",
+  "dockerFile": "Dockerfile",
+  "context": "../",
+
+  "customizations": {
+    "vscode": {
+      "settings": {
+        "terminal.integrated.defaultProfile.linux": "bash"
+      },
+      "extensions": [
+        "golang.go"
+      ],
+    }
+  },
+  "postStartCommand": "git config --global --add safe.directory /workspaces/hwloc-go"
+}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,0 +1,34 @@
+name: test hwloc-go
+
+on:
+  pull_request: []
+  workflow_dispatch:
+
+jobs:
+  test:
+    name: Test hwloc-go
+    runs-on: ubuntu-latest
+    container:
+      image: golang:bookworm
+    steps:
+    - uses: actions/checkout@v4
+    - name: Setup Go
+      uses: actions/setup-go@v4
+      with:
+        go-version: ^1.21
+
+    - name: Install dependencies
+      run: |
+        apt-get update
+        apt-get install -y locales autoconf libtool automake build-essential
+    - name: Install hwloc
+      run: |
+        git clone https://github.com/open-mpi/hwloc /opt/hwloc && \
+        cd /opt/hwloc && \
+        ./autogen.sh && \
+        ./configure --enable-static --disable-shared LDFLAGS="-static" && \
+        make LDFLAGS=-all-static && \
+        make install && ldconfig /usr/local/lib      
+
+    - name: Test 
+      run: go test -v ./...

--- a/README.md
+++ b/README.md
@@ -22,6 +22,23 @@ sudo make install
 sudo ldconfig /usr/local/lib
 ```
 
+## Development
+
+We have a [VSCode Developer Environment](.devcontainer) if you want to quickly create an environment with hwloc to develop. Once you start the container, try running the tests:
+
+```bash
+go test -v ./...
+```
+```console
+# go test -v ./...
+=== RUN   TestHwlocSetMemBind
+--- PASS: TestHwlocSetMemBind (0.69s)
+=== RUN   TestNewTopology
+--- PASS: TestNewTopology (0.49s)
+PASS
+ok      github.com/c0mm4nd/go-hwloc
+```
+
 ## Usage
 
 ```go

--- a/bitmap.go
+++ b/bitmap.go
@@ -3,7 +3,6 @@
 package hwloc
 
 //#cgo LDFLAGS: -lhwloc
-//#cgo LDFLAGS: -static -static-libgcc
 // #include <hwloc.h>
 // #include <hwloc/bitmap.h>
 import "C"

--- a/bitmap_windows.go
+++ b/bitmap_windows.go
@@ -1,7 +1,6 @@
 package hwloc
 
 //#cgo LDFLAGS: -lhwloc
-//#cgo LDFLAGS: -static -static-libgcc
 // #include <hwloc.h>
 // #include <hwloc/bitmap.h>
 import "C"

--- a/cpuset.go
+++ b/cpuset.go
@@ -3,7 +3,6 @@
 package hwloc
 
 //#cgo LDFLAGS: -lhwloc
-//#cgo LDFLAGS: -static -static-libgcc
 // #include <stdint.h>
 // #include <hwloc.h>
 import "C"

--- a/cpuset_windows.go
+++ b/cpuset_windows.go
@@ -1,7 +1,6 @@
 package hwloc
 
 //#cgo LDFLAGS: -lhwloc
-//#cgo LDFLAGS: -static -static-libgcc
 // #include <stdint.h>
 // #include <hwloc.h>
 import "C"

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/c0mm4nd/go-hwloc
+
+go 1.21

--- a/mem.go
+++ b/mem.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package hwloc

--- a/mem.go
+++ b/mem.go
@@ -4,7 +4,6 @@
 package hwloc
 
 //#cgo LDFLAGS: -lhwloc
-//#cgo LDFLAGS: -static -static-libgcc
 // #include <stdint.h>
 // #include <hwloc.h>
 import "C"

--- a/mem_windows.go
+++ b/mem_windows.go
@@ -1,7 +1,6 @@
 package hwloc
 
 //#cgo LDFLAGS: -lhwloc
-//#cgo LDFLAGS: -static -static-libgcc
 // #include <stdint.h>
 // #include <hwloc.h>
 import "C"

--- a/object.go
+++ b/object.go
@@ -3,7 +3,6 @@
 package hwloc
 
 //#cgo LDFLAGS: -lhwloc
-//#cgo LDFLAGS: -static -static-libgcc
 // #include <stdint.h>
 // #include <hwloc.h>
 /*

--- a/object_windows.go
+++ b/object_windows.go
@@ -1,7 +1,6 @@
 package hwloc
 
 //#cgo LDFLAGS: -lhwloc
-//#cgo LDFLAGS: -static -static-libgcc
 // #include <stdint.h>
 // #include <hwloc.h>
 /*

--- a/topology.go
+++ b/topology.go
@@ -4,7 +4,6 @@
 package hwloc
 
 //#cgo LDFLAGS: -lhwloc
-//#cgo LDFLAGS: -static -static-libgcc
 // #include <stdint.h>
 // #include <hwloc.h>
 import "C"

--- a/topology.go
+++ b/topology.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package hwloc
@@ -19,7 +20,7 @@ type Topology struct {
 }
 
 func NewTopology() (*Topology, error) {
-	var topology C.hwloc_topology_t = &C.struct_hwloc_topology{}
+	var topology C.hwloc_topology_t
 	C.hwloc_topology_init(&topology) // initialization
 
 	return &Topology{

--- a/topology_windows.go
+++ b/topology_windows.go
@@ -1,7 +1,6 @@
 package hwloc
 
 //#cgo LDFLAGS: -lhwloc
-//#cgo LDFLAGS: -static -static-libgcc
 // #include <stdint.h>
 // #include <hwloc.h>
 import "C"

--- a/types.go
+++ b/types.go
@@ -3,7 +3,6 @@
 package hwloc
 
 //#cgo LDFLAGS: -lhwloc
-//#cgo LDFLAGS: -static -static-libgcc
 // #include <stdint.h>
 // #include <hwloc.h>
 import "C"

--- a/types_windows.go
+++ b/types_windows.go
@@ -1,7 +1,6 @@
 package hwloc
 
 //#cgo LDFLAGS: -lhwloc
-//#cgo LDFLAGS: -static -static-libgcc
 // #include <stdint.h>
 // #include <hwloc.h>
 import "C"


### PR DESCRIPTION
Problem: the current version does not have a go module, and the build / run will fail with recent versions of go (cgo) that do not allow creating an empty struct. This is an attempt to fix that. I will need to test it to see if it actually works. I am also adding GitHub CI (to run go test) along with a VSCode developer container environment that has hwloc ready to go for easier development.

I'm going to do a quick test with my branch here (via a PR that specifies a different module path) and can report back.